### PR TITLE
Removed winsound import that's not available on Linux

### DIFF
--- a/bin/xstest.py
+++ b/bin/xstest.py
@@ -34,7 +34,6 @@ Vandenbout and then ported to python.
 """
 
 import string
-import winsound
 from argparse import ArgumentParser
 import xstools.xsboard as XSBOARD
 import xstools.xserror as XSERROR
@@ -63,7 +62,6 @@ while(True):
             try:
                 xs_board.do_self_test()
             except XSERROR.XsError as e:
-                winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
                 xs_board.xsusb.disconnect()
                 if args.multiple:
                     while XSBOARD.XsUsb.get_num_xsusb() != 0:
@@ -72,7 +70,6 @@ while(True):
                 else:
                     exit()
             print "Success:", xs_board.name, "passed diagnostic test!"
-            winsound.MessageBeep()
             xs_board.xsusb.disconnect()
             if args.multiple:
                 while XSBOARD.XsUsb.get_num_xsusb() != 0:

--- a/bin/xsusbprg.py
+++ b/bin/xsusbprg.py
@@ -38,7 +38,6 @@ code and integrated them into this program and the XSTOOLs classes and methods.
 """
 
 import string
-import winsound
 from argparse import ArgumentParser
 import xstools.xsboard as XSBOARD
 import xstools.xserror as XSERROR
@@ -78,7 +77,6 @@ while(True):
                     xs_board.update_firmware(args.filename)
                     print 'Programming complete!'
             except XSERROR.XsError as e:
-                winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
                 xs_board.xsusb.disconnect()
                 if args.multiple:
                     while XSBOARD.XsUsb.get_num_xsusb() != 0:
@@ -86,7 +84,6 @@ while(True):
                     continue
                 else:
                     exit()
-            winsound.MessageBeep()
             xs_board.xsusb.disconnect()
             if args.multiple:
                 while XSBOARD.XsUsb.get_num_xsusb() != 0:


### PR DESCRIPTION
Enables xstest and usbprg to work on Linux w/o winsound.  This change just removes the imports (and the sound).

Could guard the imports by OS for sound only on Windows, or could use pygame al la: http://code.activestate.com/recipes/521884-play-sound-files-with-pygame-in-a-cross-platform-m/

I tried using pygame, but it's pretty slow to setup and tear down the whole engine just to play a sound. (~1 second, but a noticeable hang)
